### PR TITLE
added the Capybara.app = app to the spec_helper to allow tests to work

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,3 +16,4 @@ def app
   Rack::Builder.parse_file('config.ru').first
 end
 
+Capybara.app = app


### PR DESCRIPTION
@AnnJohn 

This issue came up during a learn verified user trying to pass some tests. This was the missing command that allowed tests to run.