### PR TITLE
minor typos, and re-remove db/migrate/

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,24 +4,24 @@
 
 1. Learn about bcrypt, a gem that works to encrypt passwords
 2. Learn about Active Record's `has_secure_password` method
-3. Sign up and in a user with a secure, encrypted password. 
+3. Sign up and log in a user with a secure, encrypted password. 
 
 ## Overview
 
 Securing users' data is one of the most important jobs of a web developer. Despite frequent warnings against it, many of your users will use the same username and password combination across many different websites. This means that, in general, people will use the same password for our applications that they do for their bank. 
 
-Because of this, we never want to store our users' passwords in plain text in our database. Instead, we'll run the passwords through a hashing algorithm. A hashing algorithm manipulates data in such a way that it cannot be un-manipulated. This is to say that if someone got a hold of the hashed version of a password, they would have no way to turn it back into the original. In addition to hashing the password, we'll also add a "salt". A salt is simply a random string of characters that gets added into the hash. That way, if two of our users use the password "fido", they will end up with different hashes in our database. 
+Because of this, we never want to store our users' passwords in plain text in our database. Instead, we'll run the passwords through a [hashing algorithm](https://en.wikipedia.org/wiki/Cryptographic_hash_function). A hashing algorithm manipulates data in such a way that it cannot be un-manipulated. This is to say that if someone got a hold of the hashed version of a password, they would have no way to turn it back into the original. In addition to hashing the password, we'll also add a "salt". A salt is simply a random string of characters that gets added into the hash. That way, if two of our users use the password "fido", they will end up with different hashes in our database. 
 
-We'll use an open-source gem, `bcrypt`, to implement this strategy.
+[Bcrypt](https://en.wikipedia.org/wiki/Bcrypt) is an algorithm commonly used for the storage of password hashes on many platforms (Ruby, Javascript, Python, C, etc.). We'll use the open-source gem, `bcrypt`, to implement this strategy.
   
 ## Starter Code
 
 We've got a basic Sinatra MVC application. In our `application_controller` we have two helper methods defined: `logged_in?` returns true or false based on the presence of a `session[:user_id]` and `current_user` returns the instance of the logged in user, based on the `session[:user_id]`. We have five actions defined: 
 
-+ `get "/" do` renders an `index.erb` file with links to signup or login. 
-+ `get '/signup'` renders a form to create a new user. The form includes fields form `username` and `password`. 
++ `get '/' do` renders an `index.erb` file with links to signup or login. 
++ `get '/signup'` renders a form to create a new user. The form includes fields for `username` and `password`. 
 + `get '/login'` renders a form for logging in.
-+ `get '/success'` renders a `success.erb` page, which should be displayed once a user successfully logs in
++ `get '/success'` renders a `success.erb` page, which should be displayed once a user successfully logs in.
 + `get '/failure'` renders a `failure.erb` page. This will be accessed if there is an error logging in or signing up. 
 + `get '/logout'` clears the session data and redirects to the home page.
 
@@ -57,9 +57,9 @@ Run this migration using `rake db:migrate`. Awesome job!
 
 ### ActiveRecord's `has_secure_password`
 
-Next, let's update our user model so that it includes `has_secure_password`. This ActiveRecord macro gives us access to a few new methods. A macro is a method that when called, creates methods for you. This is meta programming, which you don't need to worry about now. Just know that using a macros is just like calling a normal ruby method.
+Next, let's update our user model so that it includes `has_secure_password`. This ActiveRecord macro gives us access to a few new methods. A macro is a method that when called, creates methods for you. This is meta programming, which you don't need to worry about now. Just know that using a macro is just like calling a normal ruby method.
 
-In this case, the macro `has_secure_password` is being called just like a normal ruby method. It works in conjunction with a gem called `bcrypt` and gives us all of those abilities in a secure way that doesn't actually store the plain text password in the database.
+In this case, the macro `has_secure_password` is being called just like a normal ruby method. It works in conjunction with the `bcrypt` gem and gives us the ability to store passwords in a secure way where we're not actually storing the plain text password in the database.
 
 
 ```ruby


### PR DESCRIPTION
A few minor typos in README.

`db/migrate` folder and the migration were still present.  REAMDE says to create them.