### PR TITLE
fix false reference to bcrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,12 +138,13 @@ post "/login" do
 end
 ```
 
-We also need to check if that user's password matches up with the value in `password_digest`. We can use a method called `authenticate`. The method is
-provided for us by the bcrypt gem. Our `authenticate` method takes a string as
-an argument. If the string matches up against the password digest, it will
-return the user object, otherwise it will return false. Therefore, we can check
-that we have a user AND that the user is authenticated. If so, we'll set the `session[:user_id]` and redirect to the `/success` route. Otherwise, we'll
-redirect to the `/failure` route so our user can try again.
+We also need to check if that user's password matches up with the value in `password_digest`. We can use a method called `authenticate`, which is also
+provided for us by `has_secure_password`. Our `authenticate` method takes a
+string as an argument. If the string matches up against the password digest,
+it will return the user object, otherwise it will return false. Therefore, we
+can check that we have a user AND that the user is authenticated. If so, we'll
+set the `session[:user_id]` and redirect to the `/success` route. Otherwise, 
+we'll redirect to the `/failure` route so our user can try again.
 
 ```ruby
 post "/login" do


### PR DESCRIPTION
A small tweak to remove a reference to bcrypt as the source of #authenticate.