### PR TITLE
Helper methods refer to incorrect attribute

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,11 +47,11 @@ class ApplicationController < Sinatra::Base
 
 	helpers do
 		def logged_in?
-			!!session[:user_id]
+			!!session[:id]
 		end
 
 		def current_user
-			User.find(session[:user_id])
+			User.find(session[:id])
 		end
 	end
 


### PR DESCRIPTION
Should be session[:id] not session[:user.id] - unless column is renamed in DB to user_id